### PR TITLE
Fix typo in delete customer API description

### DIFF
--- a/Dane-Food-API/1.0.0/spec.yaml
+++ b/Dane-Food-API/1.0.0/spec.yaml
@@ -104,7 +104,7 @@ paths:
           description: 'Conflict.'
     delete:
       summary: 'Delete Customer By ID'
-      description: 'Delete a single Customer by its Id value.'
+      description: 'Delete a single Customer by its ID value.'
       tags:
         - 'Customers'
       operationId: 'deleteCustomerByIdV1'

--- a/Dane-Food-API/1.0.0/spec.yaml
+++ b/Dane-Food-API/1.0.0/spec.yaml
@@ -65,7 +65,7 @@ paths:
   /v1/customers/{customerId}:
     get:
       summary: 'Get Customer By ID'
-      description: 'Get a single Customer by its Id value.'
+      description: 'Get a single Customer by its ID value.'
       tags:
         - 'Customers'
       operationId: 'getCustomerByIdV1'


### PR DESCRIPTION
Corrected 'Id' to 'ID' for consistency in documentation.